### PR TITLE
Fix rabbitmqctl cluster_name regexp extractor

### DIFF
--- a/tasks/rabbitmq_cluster.yml
+++ b/tasks/rabbitmq_cluster.yml
@@ -26,7 +26,7 @@
 # https://unix.stackexchange.com/a/13472
 - name: Get rabbitmq cluster name
   shell: |
-    rabbitmqctl -q cluster_status | grep -oP '(?<={cluster_name,<<").*(?=">>})'
+    rabbitmqctl -q cluster_status | paste -sd '' - | sed 's/ //g' | grep -oP '(?<={cluster_name,<<").*(?=">>})'
   args:
     executable: /bin/bash
   changed_when: false


### PR DESCRIPTION
rabbitmqctl outputs can be multilined if some lines are too long, 
thus breaking the grep regexp. 
This can happen if container's hostname is too long.

Adding the "paste" and removing spaces ensures the cluster_name
can be extracted